### PR TITLE
Fix issue preventing ollama service from being exposed on Internet

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -54,9 +54,8 @@ services:
     container_name: ollama_demo_service
     volumes:
       - ollama:/root/.ollama
-    #network_mode: host
-    ports:
-      - "11434:11434"
+    networks:
+      - public
     environment:
       - "OLLAMA_HOST=0.0.0.0:11434"
     tty: true
@@ -69,14 +68,15 @@ services:
       - open-webui:/app/backend/data
     depends_on:
       - ollama_demo_service
-    network_mode: host
-    #ports:
-    #  - "7863:7863"
+    networks:
+      - public
+    ports:
+      - "7861:7861"
     environment:
       - 'PORT=7861'
       - 'ENV=dev'
       - 'VECTOR_DB=chroma'
-      - 'OLLAMA_BASE_URL=http://0.0.0.0:11434'
+      - 'OLLAMA_BASE_URL=http://ollama_demo_service:11434'
       - 'WEBUI_NAME=Ampere Llama Chat'
       - 'ENABLE_LITELLM=False'
       - 'WEBUI_SECRET_KEY='
@@ -86,3 +86,7 @@ services:
 volumes:
   ollama: {}
   open-webui: {}
+
+networks:
+  public:
+    driver: bridge


### PR DESCRIPTION
Move ollama and webui containers to a public bridge network, expose port 7861 to allow Internet connections to the service, and set host name to container name for communication.

Adding the containers to a bridge network is best practice. The port 11434 does not need to be exposed to the Internet. Finally, the port 7861 does need to be exposed.

In addition, the host firewall will need to have IP Masquerading turned on to allow the ollama container to connect to the model registry, and the host's ethernet device needs to be added to the "devices" field for the public firewalld zone. I will propose a separate change in the README for these steps.

To enable the WebUI to start the ollama service, the container needs to be rebuilt to include this compose.yaml. 